### PR TITLE
Hotfix/he c validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ postgres.json
 rds.json
 *.ipynb
 *.debug
+*.pyc

--- a/bi_utils/transformers/hierarchical_encoder.py
+++ b/bi_utils/transformers/hierarchical_encoder.py
@@ -29,8 +29,8 @@ class HierarchicalEncoder(BaseEstimator, TransformerMixin):
         self.verbose = verbose
 
     def _check_params(self, X: pd.DataFrame) -> None:
-        if self.C <= 1:
-            raise ValueError(f'C={self.C} must be > 1')
+        if self.C <= 0:
+            raise ValueError(f'C={self.C} must be > 0')
 
     def _disambiguate(self, X: pd.DataFrame, sep: str = '__') -> pd.DataFrame:
         '''


### PR DESCRIPTION
Allow C >= 0 (used to be C>1)
Because C<1 may be legitimate for arbitrary sample-unbound weights