### PR TITLE
ci: use self-hosted runners instead of ubuntu-latest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, docker]
     strategy:
       matrix:
         python-version: ['3.9', '3.10']


### PR DESCRIPTION
Routes `ubuntu-latest` jobs to the default self-hosted runner group (`[self-hosted, docker]`). Part of the GitHub Actions cost / self-hosted migration.